### PR TITLE
Support searching class through annotations in DexClassFinder

### DIFF
--- a/yukireflection-core/src/main/java/com/highcapable/yukireflection/finder/classes/DexClassFinder.kt
+++ b/yukireflection-core/src/main/java/com/highcapable/yukireflection/finder/classes/DexClassFinder.kt
@@ -268,6 +268,21 @@ class DexClassFinder internal constructor(
         rulesData.extendsClass.addAll(name.toList())
     }
 
+    /** 设置 [Class] 修饰的注解 */
+    inline fun <reified T> annotations() {
+        rulesData.annotationClass.add(T::class.java.name)
+    }
+
+    /**
+     * 设置 [Class] 修饰的注解
+     *
+     * 会同时查找 [name] 中所有匹配的注解类
+     * @param name [Class] 完整名称
+     */
+    fun annotations(vararg name: String) {
+        rulesData.annotationClass.addAll(name.toList())
+    }
+
     /** 设置 [Class] 实现的接口类 */
     inline fun <reified T> implements() {
         rulesData.implementsClass.add(T::class.java.name)

--- a/yukireflection-core/src/main/java/com/highcapable/yukireflection/finder/classes/data/ClassRulesData.kt
+++ b/yukireflection-core/src/main/java/com/highcapable/yukireflection/finder/classes/data/ClassRulesData.kt
@@ -49,6 +49,7 @@ import java.lang.reflect.Method
  * @param isNoExtendsClass 无继承的父类
  * @param isNoImplementsClass 无继承的实现的接口类
  * @param extendsClass 继承的父类名称数组
+ * @param annotationClass 注解类名称数组
  * @param implementsClass 实现的接口类名称数组
  * @param enclosingClass 包含的封闭类 (主类) 名称数组
  * @param memberRules [Member] 查找条件数据数组
@@ -68,6 +69,7 @@ internal class ClassRulesData internal constructor(
     var isNoExtendsClass: Boolean? = null,
     var isNoImplementsClass: Boolean? = null,
     var extendsClass: MutableList<String> = mutableListOf(),
+    var annotationClass: MutableList<String> = mutableListOf(),
     var implementsClass: MutableList<String> = mutableListOf(),
     var enclosingClass: MutableList<String> = mutableListOf(),
     var memberRules: MutableList<MemberRulesData> = mutableListOf(),
@@ -152,6 +154,7 @@ internal class ClassRulesData internal constructor(
             isAnonymousClass?.let { "isAnonymousClass:[$it]" } ?: "",
             isNoExtendsClass?.let { "isNoExtendsClass:[$it]" } ?: "",
             isNoImplementsClass?.let { "isNoImplementsClass:[$it]" } ?: "",
+            annotationClass.takeIf { it.isNotEmpty() }?.let { "annotationClass:$it" } ?: "",
             extendsClass.takeIf { it.isNotEmpty() }?.let { "extendsClass:$it" } ?: "",
             implementsClass.takeIf { it.isNotEmpty() }?.let { "implementsClass:$it" } ?: "",
             enclosingClass.takeIf { it.isNotEmpty() }?.let { "enclosingClass:$it" } ?: "",
@@ -166,10 +169,10 @@ internal class ClassRulesData internal constructor(
     override val isInitialize
         get() = super.isInitialize || fromPackages.isNotEmpty() || fullName != null || simpleName != null || singleName != null ||
             fullNameConditions != null || simpleNameConditions != null || singleNameConditions != null || isAnonymousClass != null ||
-            isNoExtendsClass != null || isNoImplementsClass != null || extendsClass.isNotEmpty() || enclosingClass.isNotEmpty() ||
+            isNoExtendsClass != null || isNoImplementsClass != null || annotationClass.isNotEmpty() || extendsClass.isNotEmpty() || enclosingClass.isNotEmpty() ||
             memberRules.isNotEmpty() || fieldRules.isNotEmpty() || methodRules.isNotEmpty() || constroctorRules.isNotEmpty()
 
     override fun toString() = "[$fromPackages][$fullName][$simpleName][$singleName][$fullNameConditions][$simpleNameConditions]" +
-        "[$singleNameConditions][$modifiers][$isAnonymousClass][$isNoExtendsClass][$isNoImplementsClass][$extendsClass][$implementsClass]" +
+        "[$singleNameConditions][$modifiers][$isAnonymousClass][$isNoExtendsClass][$isNoImplementsClass][$annotationClass][$extendsClass][$implementsClass]" +
         "[$enclosingClass][$memberRules][$fieldRules][$methodRules][$constroctorRules]" + super.toString()
 }

--- a/yukireflection-core/src/main/java/com/highcapable/yukireflection/finder/tools/ReflectionTool.kt
+++ b/yukireflection-core/src/main/java/com/highcapable/yukireflection/finder/tools/ReflectionTool.kt
@@ -166,6 +166,8 @@ internal object ReflectionTool {
                     simpleNameConditions?.also { instance.simpleName.also { n -> runCatching { and(it(n.cast(), n)) } } }
                     singleNameConditions?.also { classSingleName(instance).also { n -> runCatching { and(it(n.cast(), n)) } } }
                     modifiers?.also { runCatching { and(it(instance.cast())) } }
+                    annotationClass.takeIf { it.isNotEmpty() }
+                        ?.also { and(instance.annotations.isNotEmpty() && instance.annotations.any { e -> it.contains(e.annotationClass.qualifiedName) }) }
                     extendsClass.takeIf { it.isNotEmpty() }?.also { and(instance.hasExtends && it.contains(instance.superclass.name)) }
                     implementsClass.takeIf { it.isNotEmpty() }
                         ?.also { and(instance.interfaces.isNotEmpty() && instance.interfaces.any { e -> it.contains(e.name) }) }


### PR DESCRIPTION
支持在`searchClass`时使用`annotations<EventSubscriber>()`或者`annotations("com.teamhelper.imsdk.base.EventSubscriber")`的形式筛选出添加了某些注解的Class

```kotlin
package com.teamhelper.imsdk.base

class EventLifecycleSubscriber

@Retention(AnnotationRetention.RUNTIME)
@Target(AnnotationTarget.CLASS)
annotation class EventSubscriber

classLoader.searchClass(context) {
  extends<EventLifecycleSubscriber>()
  annotations<EventSubscriber>()
  ..or..
  annotations("com.teamhelper.imsdk.base.EventSubscriber")
}
```